### PR TITLE
Fixes composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "lib-curl" : "*"
+        "ext-curl" : "*"
     },
 
     "autoload" : {


### PR DESCRIPTION
I believe the correct requirement for this library is simply the curl extension and not necessarily the libcurl library. This allows composer to install the SDK on a Windows machine.
