### PR TITLE
Allow `on_pending` callbacks

### DIFF
--- a/source/optimalpayments/hostedpayment/callback.php
+++ b/source/optimalpayments/hostedpayment/callback.php
@@ -41,7 +41,8 @@ class Callback extends \OptimalPayments\JSONObject
          'rel' => array(
               'on_success',
               'on_decline',
-              'on_hold'
+              'on_hold',
+              'on_pending'
          ),
          'retries' => 'int',
          'returnKeys' => 'array:string',


### PR DESCRIPTION
Some orders return a pending callback and it crashes the SDK.